### PR TITLE
fix: CanvasLike type

### DIFF
--- a/src/bitmap.ts
+++ b/src/bitmap.ts
@@ -54,7 +54,7 @@ export interface ImageData {
 export interface CanvasLike {
   width: number;
 	height: number;
-  getContext(contextId: '2d'): {
+  getContext(contextId: '2d'): null | {
     getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
   };
 }


### PR DESCRIPTION
Canvas 的 getContext 方法，[有可能返回 null](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext)：
> The HTMLCanvasElement.getContext() method returns a drawing context on the canvas, or [null](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null) if the context identifier is not supported, or the canvas has already been set to a different context mode.

所以 CanvasLike 接口的类型声明在 ts 类型检查时，真正的 canvas 元素（HTMLCanvasElement 类型），通过不了，即如：
``` ts
import { Bitmap } from 'binary-bmp'

const canvas: HTMLCanvasElement = document.createElement('canvas')
Bitmap.fromCanvas(canvas) // 这里会有报错
```
